### PR TITLE
Keep basemap as a background layer once basmap is switched

### DIFF
--- a/src/L.switchBasemap.js
+++ b/src/L.switchBasemap.js
@@ -52,6 +52,7 @@ L.Control.basemapsSwitcher = L.Control.extend({
                 
                 if(!obj.layer?._map){
                     obj.layer.addTo(this._map);
+                    obj.layer.bringToBack()
                     this.activeMap = obj;
                     this._collapse();
 


### PR DESCRIPTION
If additionnal layers are added to the map, swithcing basemap might hidde them. With this change, the basemap is kept in the back.